### PR TITLE
feat(api): expose validated answers

### DIFF
--- a/db/migrations/20190712172635_create_public_answers_view.sql
+++ b/db/migrations/20190712172635_create_public_answers_view.sql
@@ -1,0 +1,21 @@
+-------------------------------------- UP --------------------------------------
+
+CREATE VIEW api.public_answers AS
+SELECT
+    id,
+    parent_id,
+    value,
+    generic_reference,
+    is_published,
+    created_at,
+    updated_at,
+    question_id,
+    agreement_id
+  FROM api.answers answers
+  WHERE answers.state = 'validated';
+
+GRANT SELECT ON api.public_answers TO anonymous;
+
+------------------------------------- DOWN -------------------------------------
+
+DROP VIEW api.public_answers;

--- a/db/migrations/20190715152518_expose_answers_references_table.sql
+++ b/db/migrations/20190715152518_expose_answers_references_table.sql
@@ -1,0 +1,7 @@
+-------------------------------------- UP --------------------------------------
+
+GRANT SELECT ON api.answers_references TO anonymous;
+
+------------------------------------- DOWN -------------------------------------
+
+REVOKE SELECT ON api.answers_references FROM anonymous;

--- a/db/migrations/knex/20190712172635_create_public_answers_view.js
+++ b/db/migrations/knex/20190712172635_create_public_answers_view.js
@@ -1,0 +1,9 @@
+const getMigrationQuery = require("../../../scripts/db/getMigrationQuery");
+
+exports.up = async knex => {
+  await knex.raw(getMigrationQuery("20190712172635_create_public_answers_view").up());
+};
+
+exports.down = async knex => {
+  await knex.raw(getMigrationQuery("20190712172635_create_public_answers_view").down());
+};

--- a/db/migrations/knex/20190715152518_expose_answers_references_table.js
+++ b/db/migrations/knex/20190715152518_expose_answers_references_table.js
@@ -1,0 +1,9 @@
+const getMigrationQuery = require("../../../scripts/db/getMigrationQuery");
+
+exports.up = async knex => {
+  await knex.raw(getMigrationQuery("20190715152518_expose_answers_references_table").up());
+};
+
+exports.down = async knex => {
+  await knex.raw(getMigrationQuery("20190715152518_expose_answers_references_table").down());
+};


### PR DESCRIPTION
**Answers** (only `state=validated` ones are publicly visible)
https://contributions-api.codedutravail.num.social.gouv.fr/public_answers

**Questions**
https://contributions-api.codedutravail.num.social.gouv.fr/questions

**Agreements**
https://contributions-api.codedutravail.num.social.gouv.fr/agreements

**References**
https://contributions-api.codedutravail.num.social.gouv.fr/public_references

[Here is the documentation](http://postgrest.org/en/v5.2/api.html#) on how to use the selecting, filtering, ordering & pagination.